### PR TITLE
Remove built-in string test

### DIFF
--- a/test/tests/specIsPrototypeOf.js
+++ b/test/tests/specIsPrototypeOf.js
@@ -50,9 +50,9 @@ tests({
 	'It should also return true if the prototype chain is indirect.': function () {
 		eq(myPrototypeOf(Object.prototype, myDog), true);
 	},
-	'It should be able to compare the built-in String': function () {
-		eq(myPrototypeOf(String.prototype, 'two'), true);
-	},
+// 	'It should be able to compare the built-in String': function () {
+// 		eq(myPrototypeOf(String.prototype, 'two'), true);
+// 	},
 	'It should be able to compare the built-in Array.': function () {
 		eq(myPrototypeOf(Array.prototype, []), true);
 	},


### PR DESCRIPTION
I experimented in the console and couldn't get the native method to behave this way. Let me know what you think!